### PR TITLE
feat(frontend): 完成基础架构搭建，配置Pinia状态管理和i18n国际化

### DIFF
--- a/frontend/src/lang/en_US.ts
+++ b/frontend/src/lang/en_US.ts
@@ -1,0 +1,12 @@
+export default {
+  language: 'English',
+  app: {
+    name: 'Paper Assistant',
+  },
+  common: {
+    confirm: 'Confirm',
+    cancel: 'Cancel',
+    submit: 'Submit',
+    reset: 'Reset',
+  },
+}

--- a/frontend/src/lang/index.ts
+++ b/frontend/src/lang/index.ts
@@ -1,0 +1,17 @@
+import { createI18n } from 'vue-i18n'
+import zh_CN from './zh_CN'
+import en_US from './en_US'
+
+const messages = {
+  'zh-CN': zh_CN,
+  'en-US': en_US,
+}
+
+const i18n = createI18n({
+  legacy: false, // 使用Composition API模式
+  locale: 'zh-CN',
+  fallbackLocale: 'en-US',
+  messages,
+})
+
+export default i18n

--- a/frontend/src/lang/zh_CN.ts
+++ b/frontend/src/lang/zh_CN.ts
@@ -1,0 +1,12 @@
+export default {
+  language: '中文',
+  app: {
+    name: '论文助手',
+  },
+  common: {
+    confirm: '确认',
+    cancel: '取消',
+    submit: '提交',
+    reset: '重置',
+  },
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,10 +3,14 @@ import App from './App.vue'
 import router from './router'
 import TDesign from 'tdesign-vue-next'
 import 'tdesign-vue-next/es/style/index.css'
+import pinia from './stores'
+import i18n from './lang'
 
 const app = createApp(App)
 
 app.use(router)
 app.use(TDesign)
+app.use(pinia)
+app.use(i18n)
 
 app.mount('#app')

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -1,0 +1,23 @@
+import { defineStore } from 'pinia'
+
+export const useAppStore = defineStore('app', {
+  state: () => ({
+    title: 'PaperAgent',
+    language: 'zh-CN',
+  }),
+  
+  actions: {
+    setLanguage(lang: string) {
+      this.language = lang
+    },
+    
+    setTitle(title: string) {
+      this.title = title
+    },
+  },
+  
+  persist: {
+    key: 'app-store',
+    storage: localStorage,
+  },
+})

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -1,0 +1,7 @@
+import { createPinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+
+const pinia = createPinia()
+pinia.use(piniaPluginPersistedstate)
+
+export default pinia


### PR DESCRIPTION
完成了前端基础架构搭建任务：
1. 配置了Pinia状态管理，包括安装依赖、创建配置文件和示例store
2. 配置了i18n国际化功能，支持中英文切换
3. 更新了任务清单状态