### PR TITLE
fix(backend): 修改禁止注册系统的bug

### DIFF
--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -17,7 +17,7 @@ class User(Base):
     is_active = Column(Boolean, default=True)
 
 class SystemConfig(Base):
-    __tablename__ = "system_configs"
+    __tablename__ = "system_config"
     
     id = Column(Integer, primary_key=True, index=True)
     is_allow_register = Column(Boolean, nullable=False, default=True)


### PR DESCRIPTION
- 将 SystemConfig 模型的 __tablename__ 属性从 "system_configs" 改为 "system_config"
- 这个改动统一了表名的命名方式，使其与其他模型保持一致