### PR TITLE
fix(ci): disable Buildx attestations so Aliyun ACR accepts image push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,10 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         platforms: linux/amd64
+        # Aliyun ACR (free) rejects BuildKit OCI artifact attestations
+        # (application/vnd.oci.empty.v1+json). Disable default provenance/SBOM.
+        provenance: false
+        sbom: false
 
     - name: Deploy to server
       run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Newer BuildKit / Buildx (especially BuildKit ≥ v0.32.0, including `moby/buildkit:buildx-stable-1`) attaches provenance / SBOM attestations as OCI artifacts:

- `artifactType: application/vnd.docker.attestation.manifest.v1+json`
- `config.mediaType: application/vnd.oci.empty.v1+json`

Aliyun ACR free tier (and some older Harbor / Distribution registries) reject `vnd.oci.empty.v1+json`, so `docker/build-push-action` fails even though the Dockerfile and tags are fine.

## Fix

Disable default attestations in `.github/workflows/deploy.yml` so the registry only receives a normal image manifest:

```yaml
provenance: false
sbom: false
```

This is the fastest fix for domestic / ACR-free registries. Attestations can be re-enabled later with `oci-artifact=false` or by upgrading the registry.

## Test plan

- YAML parses cleanly; `docker/build-push-action@v6` declares `provenance` and `sbom` inputs.
- After merge, the next `master` deploy should push without the attestation media-type denial. A real ACR push cannot be verified from this PR environment (registry credentials are GitHub secrets; the deploy workflow only runs on `master`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab88d3e9-6e6a-444e-ab59-c9f61f91f397?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab88d3e9-6e6a-444e-ab59-c9f61f91f397&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

