### PR TITLE
fix(frontend): 修复 Safari 下 loading 圆环自转兼公转

### DIFF
--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -422,35 +422,28 @@ h6 {
   font-family: var(--td-font-family-heading);
 }
 
-/* TDesign spinner = SVG (1em) wrapping a 12x12 foreignObject.
-   Size the SVG, never the inner .t-loading__gradient-conic — 1em there
-   overflows the FO and clips into a triangle. */
+/* Safari: TDesign's spinner is an SVG + foreignObject. Rotating the SVG
+   leaves the conic off-center (spin + orbit). CSS border-radius on <svg>
+   is also ignored, so a square outline revolves. Hide the SVG and spin a
+   regular HTML ring around its own center. */
 .t-loading {
   line-height: 1;
   flex-shrink: 0;
 }
 
-.t-button .t-loading,
-svg.t-loading__gradient,
-.t-icon-loading {
-  width: 1em;
-  height: 1em;
-  max-width: 1em;
-  max-height: 1em;
-  flex-shrink: 0;
-  overflow: hidden;
+.t-loading > svg.t-loading__gradient {
+  display: none !important;
 }
 
-.t-loading__gradient-conic {
-  width: 100% !important;
-  height: 100% !important;
-  min-width: 0 !important;
-  min-height: 0 !important;
+.t-loading:has(> svg.t-loading__gradient)::before {
+  content: '';
   box-sizing: border-box;
+  width: 1em;
+  height: 1em;
+  flex: 0 0 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
   border-radius: 50%;
-  /* iOS Safari / CriOS: TDesign scales the conic from 0,0 by fontSize/12,
-     which clips a 100%-sized ring into a triangle. */
-  transform: none !important;
-  -webkit-transform: none !important;
-  transform-origin: center center !important;
+  transform-origin: 50% 50%;
+  animation: t-spin 0.8s linear infinite;
 }


### PR DESCRIPTION
Safari 上 TDesign loading 会同时自转和公转：外层 SVG 在转，foreignObject 里的圆环中心却不在圆心；SVG 的 `border-radius` 也被忽略，看起来像方框角在绕圈。

## 改动

- 隐藏 TDesign 原生 SVG spinner
- 用 `.t-loading::before` 画 1em HTML 圆环，只绕自身中心旋转

## 验证

- 登录按钮 loading：桌面 Chrome 与 iPhone Safari UA 下圆心不漂移
- 圆环为正圆，缺口绕圆心转，不再绕按钮飞