### PR TITLE
ci: 仅在对应目录变更时分别部署前后端

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,12 @@
-name: Build and Deploy
+name: Build and Deploy Backend
 
 on:
   push:
     branches: [ master ]
+    paths:
+      - "backend/**"
+      - "docker-compose.yml"
+      - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
 jobs:

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- .",
   "rewrites": [
     {
       "source": "/:path*",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

当前每次 push 到 `master` 都会同时触发：
- GitHub Actions 后端 Docker 构建并 SSH 重启生产服务
- Vercel 前端构建

因此只改 `frontend/` 也会重启后端，只改 `backend/` 也会走一遍 Vercel。

本次把两边的触发条件拆开：

- **后端（GitHub Actions）**：仅在 `backend/**`、`docker-compose.yml` 或 `.github/workflows/deploy.yml` 变更时运行；`workflow_dispatch` 仍可手动部署。
- **前端（Vercel）**：在 `frontend/vercel.json` 增加 `ignoreCommand`。项目 Root Directory 已是 `frontend`，该命令在该目录下比较 `HEAD^` 与 `HEAD`，前端无改动则跳过构建。

两边都改时仍会同时部署。合入本 PR 会同时改 workflow 与 `frontend/vercel.json`，因此这一次前后端都会部署；之后才按目录分流。

## Test plan

- [x] 用历史提交模拟 GitHub `paths` 过滤：纯前端 commit（如 #267 / #265 / #249）不匹配后端路径，不会跑 GHA 部署
- [x] 用历史提交模拟 Vercel `ignoreCommand`：纯后端 / 纯 CI commit（如 #263 / #264）exit 0，跳过前端构建
- [x] 前后端同时改动的 commit（如 #222）两边都触发
- [x] 校验 `deploy.yml` YAML 与 `vercel.json` JSON 语法；CodeQL 通过
- [x] 本 PR 改了 `frontend/vercel.json`，Vercel preview 构建成功（Ready），说明 `ignoreCommand` 可被接受

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b15ddcd-04ed-4adf-b751-2eb6718df4e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b15ddcd-04ed-4adf-b751-2eb6718df4e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

