### PR TITLE
feat: 支持 Passkey 登录

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,13 @@ SECRET_KEY=your-secret-key-here
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
+# Passkey / WebAuthn（可选。未设置时从请求 Origin 自动推导 rp_id）
+# 生产环境建议显式配置；Passkey 需要 HTTPS 或 localhost
+# WEBAUTHN_RP_ID=example.com
+# WEBAUTHN_RP_NAME=PaperAgent
+# WEBAUTHN_ORIGIN=https://example.com
+# WEBAUTHN_ORIGINS=https://example.com,https://www.example.com
+
 # 应用配置
 DEBUG=True
 ALLOWED_HOSTS=localhost,127.0.0.1

--- a/backend/alembic/versions/c4e8a1b2d9f0_add_webauthn_passkey_tables.py
+++ b/backend/alembic/versions/c4e8a1b2d9f0_add_webauthn_passkey_tables.py
@@ -1,0 +1,77 @@
+"""add webauthn passkey tables
+
+Revision ID: c4e8a1b2d9f0
+Revises: 906ca23fbfe1
+Create Date: 2026-08-24 07:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c4e8a1b2d9f0"
+down_revision: Union[str, Sequence[str], None] = "906ca23fbfe1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "webauthn_credentials",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("credential_id", sa.String(length=1024), nullable=False),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column("sign_count", sa.Integer(), nullable=False),
+        sa.Column("device_type", sa.String(length=32), nullable=True),
+        sa.Column("backed_up", sa.Boolean(), nullable=True),
+        sa.Column("transports", sa.JSON(), nullable=True),
+        sa.Column("aaguid", sa.String(length=64), nullable=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_webauthn_credentials_id"), "webauthn_credentials", ["id"], unique=False)
+    op.create_index(op.f("ix_webauthn_credentials_user_id"), "webauthn_credentials", ["user_id"], unique=False)
+    op.create_index(
+        op.f("ix_webauthn_credentials_credential_id"),
+        "webauthn_credentials",
+        ["credential_id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "webauthn_challenges",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("challenge_id", sa.String(length=64), nullable=False),
+        sa.Column("challenge", sa.String(length=255), nullable=False),
+        sa.Column("challenge_type", sa.String(length=32), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_webauthn_challenges_id"), "webauthn_challenges", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_webauthn_challenges_challenge_id"),
+        "webauthn_challenges",
+        ["challenge_id"],
+        unique=True,
+    )
+    op.create_index(op.f("ix_webauthn_challenges_user_id"), "webauthn_challenges", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_webauthn_challenges_user_id"), table_name="webauthn_challenges")
+    op.drop_index(op.f("ix_webauthn_challenges_challenge_id"), table_name="webauthn_challenges")
+    op.drop_index(op.f("ix_webauthn_challenges_id"), table_name="webauthn_challenges")
+    op.drop_table("webauthn_challenges")
+    op.drop_index(op.f("ix_webauthn_credentials_credential_id"), table_name="webauthn_credentials")
+    op.drop_index(op.f("ix_webauthn_credentials_user_id"), table_name="webauthn_credentials")
+    op.drop_index(op.f("ix_webauthn_credentials_id"), table_name="webauthn_credentials")
+    op.drop_table("webauthn_credentials")

--- a/backend/auth/passkey.py
+++ b/backend/auth/passkey.py
@@ -1,0 +1,405 @@
+"""Passkey / WebAuthn 注册与登录。"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy.orm import Session
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers import bytes_to_base64url, base64url_to_bytes, options_to_json_dict
+from webauthn.helpers.exceptions import (
+    InvalidAuthenticationResponse,
+    InvalidRegistrationResponse,
+    WebAuthnException,
+)
+from webauthn.helpers.structs import (
+    AuthenticatorSelectionCriteria,
+    AuthenticatorTransport,
+    PublicKeyCredentialDescriptor,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+from models import models
+
+CHALLENGE_TTL = timedelta(minutes=5)
+DEFAULT_ORIGIN = "http://localhost:5173"
+DEFAULT_RP_ID = "localhost"
+DEFAULT_RP_NAME = "PaperAgent"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _aware(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def user_handle_for_id(user_id: int) -> bytes:
+    return user_id.to_bytes(8, "big")
+
+
+def get_relying_party(request: Request) -> tuple[str, str, str]:
+    """返回 (rp_id, rp_name, origin)。优先使用请求 Origin，可用环境变量覆盖。"""
+    rp_name = os.getenv("WEBAUTHN_RP_NAME", DEFAULT_RP_NAME)
+    origin_header = request.headers.get("origin")
+    origin_env = os.getenv("WEBAUTHN_ORIGIN")
+    origin = origin_header or origin_env or DEFAULT_ORIGIN
+
+    allowed = [item.strip() for item in os.getenv("WEBAUTHN_ORIGINS", "").split(",") if item.strip()]
+    if origin_env and origin_env not in allowed:
+        allowed.append(origin_env)
+    if allowed and origin not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid origin for passkey",
+        )
+
+    rp_id = os.getenv("WEBAUTHN_RP_ID")
+    if not rp_id:
+        hostname = urlparse(origin).hostname
+        rp_id = hostname or DEFAULT_RP_ID
+    return rp_id, rp_name, origin
+
+
+def _cleanup_expired_challenges(db: Session) -> None:
+    db.query(models.WebAuthnChallenge).filter(
+        models.WebAuthnChallenge.expires_at < _utcnow()
+    ).delete(synchronize_session=False)
+    db.commit()
+
+
+def _store_challenge(
+    db: Session,
+    *,
+    challenge: bytes,
+    challenge_type: str,
+    user_id: Optional[int] = None,
+) -> str:
+    _cleanup_expired_challenges(db)
+    challenge_id = secrets.token_urlsafe(32)
+    record = models.WebAuthnChallenge(
+        challenge_id=challenge_id,
+        challenge=bytes_to_base64url(challenge),
+        challenge_type=challenge_type,
+        user_id=user_id,
+        expires_at=_utcnow() + CHALLENGE_TTL,
+    )
+    db.add(record)
+    db.commit()
+    return challenge_id
+
+
+def _consume_challenge(
+    db: Session,
+    challenge_id: str,
+    expected_type: str,
+) -> models.WebAuthnChallenge:
+    record = (
+        db.query(models.WebAuthnChallenge)
+        .filter(models.WebAuthnChallenge.challenge_id == challenge_id)
+        .first()
+    )
+    if not record or record.challenge_type != expected_type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired passkey challenge",
+        )
+    if _aware(record.expires_at) < _utcnow():
+        db.delete(record)
+        db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired passkey challenge",
+        )
+    db.delete(record)
+    db.commit()
+    return record
+
+
+def _parse_transports(raw) -> Optional[list[AuthenticatorTransport]]:
+    if not raw:
+        return None
+    transports: list[AuthenticatorTransport] = []
+    for item in raw:
+        try:
+            transports.append(AuthenticatorTransport(item))
+        except ValueError:
+            continue
+    return transports or None
+
+
+def _credential_descriptors(credentials: list[models.WebAuthnCredential]):
+    descriptors = []
+    for cred in credentials:
+        descriptors.append(
+            PublicKeyCredentialDescriptor(
+                id=base64url_to_bytes(cred.credential_id),
+                transports=_parse_transports(cred.transports),
+            )
+        )
+    return descriptors or None
+
+
+def _default_passkey_name(credential: dict, fallback: str) -> str:
+    attachment = credential.get("authenticatorAttachment")
+    if attachment == "platform":
+        return "本机 Passkey"
+    if attachment == "cross-platform":
+        return "安全密钥"
+    return fallback
+
+
+def create_registration_options(db: Session, user: models.User, request: Request) -> dict:
+    rp_id, rp_name, _origin = get_relying_party(request)
+    existing = (
+        db.query(models.WebAuthnCredential)
+        .filter(models.WebAuthnCredential.user_id == user.id)
+        .all()
+    )
+    options = generate_registration_options(
+        rp_id=rp_id,
+        rp_name=rp_name,
+        user_id=user_handle_for_id(user.id),
+        user_name=user.email,
+        user_display_name=user.username,
+        authenticator_selection=AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.REQUIRED,
+            user_verification=UserVerificationRequirement.PREFERRED,
+        ),
+        exclude_credentials=_credential_descriptors(existing),
+    )
+    challenge_id = _store_challenge(
+        db,
+        challenge=options.challenge,
+        challenge_type="registration",
+        user_id=user.id,
+    )
+    return {
+        "challenge_id": challenge_id,
+        "options": options_to_json_dict(options),
+    }
+
+
+def verify_registration(
+    db: Session,
+    user: models.User,
+    request: Request,
+    challenge_id: str,
+    credential: dict,
+    name: Optional[str] = None,
+) -> models.WebAuthnCredential:
+    challenge = _consume_challenge(db, challenge_id, "registration")
+    if challenge.user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired passkey challenge",
+        )
+
+    rp_id, _rp_name, origin = get_relying_party(request)
+    try:
+        verification = verify_registration_response(
+            credential=credential,
+            expected_challenge=base64url_to_bytes(challenge.challenge),
+            expected_rp_id=rp_id,
+            expected_origin=origin,
+            require_user_verification=False,
+        )
+    except (InvalidRegistrationResponse, WebAuthnException) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passkey registration failed",
+        ) from exc
+
+    credential_id = bytes_to_base64url(verification.credential_id)
+    existing = (
+        db.query(models.WebAuthnCredential)
+        .filter(models.WebAuthnCredential.credential_id == credential_id)
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passkey already registered",
+        )
+
+    trimmed_name = (name or "").strip()[:100]
+    record = models.WebAuthnCredential(
+        user_id=user.id,
+        credential_id=credential_id,
+        public_key=bytes_to_base64url(verification.credential_public_key),
+        sign_count=verification.sign_count,
+        device_type=str(verification.credential_device_type.value)
+        if hasattr(verification.credential_device_type, "value")
+        else str(verification.credential_device_type),
+        backed_up=bool(verification.credential_backed_up),
+        transports=credential.get("response", {}).get("transports"),
+        aaguid=verification.aaguid,
+        name=trimmed_name or _default_passkey_name(credential, "Passkey"),
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+def create_authentication_options(
+    db: Session,
+    request: Request,
+    email: Optional[str] = None,
+) -> dict:
+    rp_id, _rp_name, _origin = get_relying_party(request)
+    user_id = None
+    allow_credentials = None
+    if email:
+        user = db.query(models.User).filter(models.User.email == email).first()
+        if user:
+            user_id = user.id
+            creds = (
+                db.query(models.WebAuthnCredential)
+                .filter(models.WebAuthnCredential.user_id == user.id)
+                .all()
+            )
+            allow_credentials = _credential_descriptors(creds)
+
+    options = generate_authentication_options(
+        rp_id=rp_id,
+        allow_credentials=allow_credentials,
+        user_verification=UserVerificationRequirement.PREFERRED,
+    )
+    challenge_id = _store_challenge(
+        db,
+        challenge=options.challenge,
+        challenge_type="authentication",
+        user_id=user_id,
+    )
+    return {
+        "challenge_id": challenge_id,
+        "options": options_to_json_dict(options),
+    }
+
+
+def verify_authentication(
+    db: Session,
+    request: Request,
+    challenge_id: str,
+    credential: dict,
+) -> models.User:
+    challenge = _consume_challenge(db, challenge_id, "authentication")
+    credential_id = credential.get("id")
+    if not credential_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passkey authentication failed",
+        )
+
+    stored = (
+        db.query(models.WebAuthnCredential)
+        .filter(models.WebAuthnCredential.credential_id == credential_id)
+        .first()
+    )
+    if not stored:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unknown passkey",
+        )
+    if challenge.user_id is not None and stored.user_id != challenge.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passkey does not match this account",
+        )
+
+    rp_id, _rp_name, origin = get_relying_party(request)
+    try:
+        verification = verify_authentication_response(
+            credential=credential,
+            expected_challenge=base64url_to_bytes(challenge.challenge),
+            expected_rp_id=rp_id,
+            expected_origin=origin,
+            credential_public_key=base64url_to_bytes(stored.public_key),
+            credential_current_sign_count=stored.sign_count,
+            require_user_verification=False,
+        )
+    except (InvalidAuthenticationResponse, WebAuthnException) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passkey authentication failed",
+        ) from exc
+
+    stored.sign_count = verification.new_sign_count
+    stored.backed_up = bool(verification.credential_backed_up)
+    if verification.credential_device_type:
+        stored.device_type = (
+            verification.credential_device_type.value
+            if hasattr(verification.credential_device_type, "value")
+            else str(verification.credential_device_type)
+        )
+    stored.last_used_at = _utcnow()
+    db.commit()
+
+    user = db.query(models.User).filter(models.User.id == stored.user_id).first()
+    if not user or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passkey authentication failed",
+        )
+    return user
+
+
+def list_credentials(db: Session, user_id: int) -> list[models.WebAuthnCredential]:
+    return (
+        db.query(models.WebAuthnCredential)
+        .filter(models.WebAuthnCredential.user_id == user_id)
+        .order_by(models.WebAuthnCredential.created_at.desc())
+        .all()
+    )
+
+
+def rename_credential(
+    db: Session, user_id: int, credential_pk: int, name: str
+) -> models.WebAuthnCredential:
+    record = (
+        db.query(models.WebAuthnCredential)
+        .filter(
+            models.WebAuthnCredential.id == credential_pk,
+            models.WebAuthnCredential.user_id == user_id,
+        )
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Passkey not found")
+    trimmed = name.strip()[:100]
+    if not trimmed:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Passkey name is required")
+    record.name = trimmed
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+def delete_credential(db: Session, user_id: int, credential_pk: int) -> None:
+    record = (
+        db.query(models.WebAuthnCredential)
+        .filter(
+            models.WebAuthnCredential.id == credential_pk,
+            models.WebAuthnCredential.user_id == user_id,
+        )
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Passkey not found")
+    db.delete(record)
+    db.commit()

--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -123,3 +123,39 @@ class WorkFlowState(Base):
 
 # 更新User模型的反向关系
 User.chat_sessions = relationship("ChatSession", back_populates="creator")
+
+
+class WebAuthnCredential(Base):
+    """用户绑定的 Passkey / WebAuthn 凭证"""
+    __tablename__ = "webauthn_credentials"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    credential_id = Column(String(1024), unique=True, nullable=False, index=True)
+    public_key = Column(Text, nullable=False)
+    sign_count = Column(Integer, nullable=False, default=0)
+    device_type = Column(String(32), nullable=True)
+    backed_up = Column(Boolean, default=False)
+    transports = Column(JSON, nullable=True)
+    aaguid = Column(String(64), nullable=True)
+    name = Column(String(100), nullable=False, default="Passkey")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+
+    user = relationship("User", back_populates="webauthn_credentials")
+
+
+class WebAuthnChallenge(Base):
+    """一次性 WebAuthn challenge，注册/登录校验后作废"""
+    __tablename__ = "webauthn_challenges"
+
+    id = Column(Integer, primary_key=True, index=True)
+    challenge_id = Column(String(64), unique=True, nullable=False, index=True)
+    challenge = Column(String(255), nullable=False)
+    challenge_type = Column(String(32), nullable=False)  # registration | authentication
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+User.webauthn_credentials = relationship("WebAuthnCredential", back_populates="user")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "langchain-anthropic>=1.4.3",
     "langchain-google-genai>=4.2.2",
     "pygments>=2.20.0",
+    "webauthn>=3.0.0",
 ]
 
 [tool.uv.workspace]

--- a/backend/routers/auth_routes/auth.py
+++ b/backend/routers/auth_routes/auth.py
@@ -7,8 +7,10 @@ from auth import auth
 from database.database import get_db
 
 from ..utils import route_guard
+from .passkey import router as passkey_router
 
 router = APIRouter(prefix="/auth",tags=["认证"])
+router.include_router(passkey_router)
 
 @router.post("/register", response_model=schemas.UserResponse)
 @route_guard

--- a/backend/routers/auth_routes/passkey.py
+++ b/backend/routers/auth_routes/passkey.py
@@ -1,0 +1,113 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from auth import auth
+from auth import passkey as passkey_service
+from database.database import get_db
+from models import models
+from schemas import schemas
+from services import crud
+
+from ..utils import route_guard
+
+router = APIRouter(prefix="/passkey", tags=["Passkey"])
+
+
+def _require_user(user_id: int, db: Session) -> models.User:
+    user = crud.get_user_by_id(db, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user
+
+
+@router.post("/register/options", response_model=schemas.PasskeyOptionsResponse)
+@route_guard
+async def passkey_register_options(
+    request: Request,
+    current_user: int = Depends(auth.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """生成绑定 Passkey 的 WebAuthn 选项"""
+    user = _require_user(current_user, db)
+    return passkey_service.create_registration_options(db, user, request)
+
+
+@router.post("/register/verify", response_model=schemas.PasskeyCredentialResponse)
+@route_guard
+async def passkey_register_verify(
+    payload: schemas.PasskeyRegisterVerifyRequest,
+    request: Request,
+    current_user: int = Depends(auth.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """校验并保存新 Passkey"""
+    user = _require_user(current_user, db)
+    return passkey_service.verify_registration(
+        db,
+        user,
+        request,
+        payload.challenge_id,
+        payload.credential,
+        payload.name,
+    )
+
+
+@router.post("/login/options", response_model=schemas.PasskeyOptionsResponse)
+@route_guard
+async def passkey_login_options(
+    request: Request,
+    payload: schemas.PasskeyLoginOptionsRequest | None = None,
+    db: Session = Depends(get_db),
+):
+    """生成 Passkey 登录选项（可不填邮箱，走可发现凭证）"""
+    email = payload.email if payload else None
+    return passkey_service.create_authentication_options(db, request, email)
+
+
+@router.post("/login/verify", response_model=schemas.Token)
+@route_guard
+async def passkey_login_verify(
+    payload: schemas.PasskeyLoginVerifyRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """校验 Passkey 断言并签发登录 token"""
+    user = passkey_service.verify_authentication(
+        db, request, payload.challenge_id, payload.credential
+    )
+    access_token = auth.create_access_token(data={"user_id": user.id})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.get("/credentials", response_model=list[schemas.PasskeyCredentialResponse])
+@route_guard
+async def list_passkeys(
+    current_user: int = Depends(auth.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """列出当前用户的 Passkey"""
+    return passkey_service.list_credentials(db, current_user)
+
+
+@router.patch("/credentials/{credential_id}", response_model=schemas.PasskeyCredentialResponse)
+@route_guard
+async def rename_passkey(
+    credential_id: int,
+    payload: schemas.PasskeyUpdateRequest,
+    current_user: int = Depends(auth.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """重命名 Passkey"""
+    return passkey_service.rename_credential(db, current_user, credential_id, payload.name)
+
+
+@router.delete("/credentials/{credential_id}")
+@route_guard
+async def delete_passkey(
+    credential_id: int,
+    current_user: int = Depends(auth.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """删除 Passkey"""
+    passkey_service.delete_credential(db, current_user, credential_id)
+    return {"status": "success"}

--- a/backend/schemas/schemas.py
+++ b/backend/schemas/schemas.py
@@ -28,6 +28,43 @@ class Token(BaseModel):
 class TokenData(BaseModel):
     email: Optional[str] = None
 
+
+class PasskeyLoginOptionsRequest(BaseModel):
+    email: Optional[EmailStr] = None
+
+
+class PasskeyOptionsResponse(BaseModel):
+    challenge_id: str
+    options: dict
+
+
+class PasskeyRegisterVerifyRequest(BaseModel):
+    challenge_id: str
+    credential: dict
+    name: Optional[str] = None
+
+
+class PasskeyLoginVerifyRequest(BaseModel):
+    challenge_id: str
+    credential: dict
+
+
+class PasskeyCredentialResponse(BaseModel):
+    id: int
+    name: str
+    device_type: Optional[str] = None
+    backed_up: bool = False
+    transports: Optional[List[str]] = None
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class PasskeyUpdateRequest(BaseModel):
+    name: str
+
 class SystemConfigResponse(BaseModel):
     id: int
     is_allow_register: bool

--- a/backend/tests/test_passkey.py
+++ b/backend/tests/test_passkey.py
@@ -1,0 +1,274 @@
+from pathlib import Path
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from database.database import get_db
+from models.models import Base, SystemConfig
+from routers.auth_routes.auth import router as auth_router
+from webauthn.helpers import bytes_to_base64url
+from webauthn.helpers.structs import CredentialDeviceType
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app = FastAPI()
+app.include_router(auth_router)
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+ORIGIN = "http://localhost:5173"
+HEADERS = {"Origin": ORIGIN}
+
+
+def _session():
+    return TestingSessionLocal()
+
+
+def setup_module(_module):
+    db = _session()
+    if not db.query(SystemConfig).first():
+        db.add(SystemConfig(is_allow_register=True))
+        db.commit()
+    db.close()
+
+
+def _register_and_login(email: str, username: str, password: str = "secret12") -> str:
+    register = client.post(
+        "/auth/register",
+        json={"email": email, "username": username, "password": password},
+    )
+    assert register.status_code == 200, register.text
+    login = client.post("/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200, login.text
+    return login.json()["access_token"]
+
+
+def _auth_headers(token: str) -> dict:
+    return {**HEADERS, "Authorization": f"Bearer {token}"}
+
+
+def _verified_registration(credential_id: bytes = b"cred-id-1"):
+    result = MagicMock()
+    result.credential_id = credential_id
+    result.credential_public_key = b"\x04public-key"
+    result.sign_count = 0
+    result.aaguid = "00000000-0000-0000-0000-000000000000"
+    result.credential_device_type = CredentialDeviceType.MULTI_DEVICE
+    result.credential_backed_up = True
+    return result
+
+
+def _verified_authentication(credential_id: bytes = b"cred-id-1"):
+    result = MagicMock()
+    result.credential_id = credential_id
+    result.new_sign_count = 1
+    result.credential_device_type = CredentialDeviceType.MULTI_DEVICE
+    result.credential_backed_up = True
+    result.user_verified = True
+    return result
+
+
+def test_register_options_requires_auth():
+    response = client.post("/auth/passkey/register/options", headers=HEADERS)
+    assert response.status_code == 401
+
+
+def test_register_options_and_list_empty():
+    token = _register_and_login("passkey-user@example.com", "passkey_user")
+    options = client.post("/auth/passkey/register/options", headers=_auth_headers(token))
+    assert options.status_code == 200, options.text
+    body = options.json()
+    assert body["challenge_id"]
+    assert body["options"]["rp"]["id"] == "localhost"
+    assert body["options"]["rp"]["name"] == "PaperAgent"
+    assert body["options"]["user"]["name"] == "passkey-user@example.com"
+    assert body["options"]["challenge"]
+    assert body["options"]["authenticatorSelection"]["residentKey"] == "required"
+
+    listed = client.get("/auth/passkey/credentials", headers=_auth_headers(token))
+    assert listed.status_code == 200
+    assert listed.json() == []
+
+
+def test_register_verify_and_login_flow():
+    token = _register_and_login("passkey-login@example.com", "passkey_login")
+    options = client.post("/auth/passkey/register/options", headers=_auth_headers(token))
+    challenge_id = options.json()["challenge_id"]
+    credential_id = bytes_to_base64url(b"cred-id-login")
+    credential = {
+        "id": credential_id,
+        "rawId": credential_id,
+        "type": "public-key",
+        "response": {"clientDataJSON": "aaa", "attestationObject": "bbb", "transports": ["internal"]},
+        "authenticatorAttachment": "platform",
+        "clientExtensionResults": {},
+    }
+
+    with patch("auth.passkey.verify_registration_response", return_value=_verified_registration(b"cred-id-login")):
+        saved = client.post(
+            "/auth/passkey/register/verify",
+            headers=_auth_headers(token),
+            json={"challenge_id": challenge_id, "credential": credential, "name": "我的笔记本"},
+        )
+    assert saved.status_code == 200, saved.text
+    saved_body = saved.json()
+    assert saved_body["name"] == "我的笔记本"
+    assert saved_body["backed_up"] is True
+    assert saved_body["transports"] == ["internal"]
+
+    listed = client.get("/auth/passkey/credentials", headers=_auth_headers(token))
+    assert len(listed.json()) == 1
+    cred_pk = listed.json()[0]["id"]
+
+    renamed = client.patch(
+        f"/auth/passkey/credentials/{cred_pk}",
+        headers=_auth_headers(token),
+        json={"name": "办公室电脑"},
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["name"] == "办公室电脑"
+
+    login_options = client.post(
+        "/auth/passkey/login/options",
+        headers=HEADERS,
+        json={"email": "passkey-login@example.com"},
+    )
+    assert login_options.status_code == 200, login_options.text
+    login_challenge = login_options.json()["challenge_id"]
+    assert login_options.json()["options"]["allowCredentials"]
+
+    assertion = {
+        "id": credential_id,
+        "rawId": credential_id,
+        "type": "public-key",
+        "response": {
+            "clientDataJSON": "aaa",
+            "authenticatorData": "bbb",
+            "signature": "ccc",
+            "userHandle": "ddd",
+        },
+        "clientExtensionResults": {},
+    }
+    with patch(
+        "auth.passkey.verify_authentication_response",
+        return_value=_verified_authentication(b"cred-id-login"),
+    ):
+        logged_in = client.post(
+            "/auth/passkey/login/verify",
+            headers=HEADERS,
+            json={"challenge_id": login_challenge, "credential": assertion},
+        )
+    assert logged_in.status_code == 200, logged_in.text
+    passkey_token = logged_in.json()["access_token"]
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {passkey_token}"})
+    assert me.status_code == 200
+    assert me.json()["email"] == "passkey-login@example.com"
+
+    replay = client.post(
+        "/auth/passkey/login/verify",
+        headers=HEADERS,
+        json={"challenge_id": login_challenge, "credential": assertion},
+    )
+    assert replay.status_code == 400
+
+
+def test_usernameless_login_options_have_no_allow_credentials():
+    response = client.post("/auth/passkey/login/options", headers=HEADERS, json={})
+    assert response.status_code == 200, response.text
+    options = response.json()["options"]
+    assert "allowCredentials" not in options or options.get("allowCredentials") in (None, [])
+
+
+def test_invalid_challenge_is_rejected():
+    token = _register_and_login("challenge-user@example.com", "challenge_user")
+    response = client.post(
+        "/auth/passkey/register/verify",
+        headers=_auth_headers(token),
+        json={
+            "challenge_id": "does-not-exist",
+            "credential": {"id": "abc", "type": "public-key", "response": {}},
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_expired_challenge_is_rejected():
+    token = _register_and_login("expired-user@example.com", "expired_user")
+    options = client.post("/auth/passkey/register/options", headers=_auth_headers(token))
+    challenge_id = options.json()["challenge_id"]
+
+    db = _session()
+    from models import models
+
+    record = (
+        db.query(models.WebAuthnChallenge)
+        .filter(models.WebAuthnChallenge.challenge_id == challenge_id)
+        .first()
+    )
+    record.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    db.commit()
+    db.close()
+
+    response = client.post(
+        "/auth/passkey/register/verify",
+        headers=_auth_headers(token),
+        json={
+            "challenge_id": challenge_id,
+            "credential": {"id": "abc", "type": "public-key", "response": {}},
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_cannot_delete_another_users_passkey():
+    owner_token = _register_and_login("owner@example.com", "owner_user")
+    other_token = _register_and_login("other@example.com", "other_user")
+    options = client.post("/auth/passkey/register/options", headers=_auth_headers(owner_token))
+    challenge_id = options.json()["challenge_id"]
+    credential_id = bytes_to_base64url(b"owner-cred")
+    credential = {
+        "id": credential_id,
+        "rawId": credential_id,
+        "type": "public-key",
+        "response": {"clientDataJSON": "a", "attestationObject": "b"},
+        "clientExtensionResults": {},
+    }
+    with patch("auth.passkey.verify_registration_response", return_value=_verified_registration(b"owner-cred")):
+        saved = client.post(
+            "/auth/passkey/register/verify",
+            headers=_auth_headers(owner_token),
+            json={"challenge_id": challenge_id, "credential": credential},
+        )
+    cred_pk = saved.json()["id"]
+
+    denied = client.delete(f"/auth/passkey/credentials/{cred_pk}", headers=_auth_headers(other_token))
+    assert denied.status_code == 404
+
+    deleted = client.delete(f"/auth/passkey/credentials/{cred_pk}", headers=_auth_headers(owner_token))
+    assert deleted.status_code == 200
+    listed = client.get("/auth/passkey/credentials", headers=_auth_headers(owner_token))
+    assert listed.json() == []

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -222,6 +222,7 @@ dependencies = [
     { name = "smolagents" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "webauthn" },
 ]
 
 [package.metadata]
@@ -259,6 +260,7 @@ requires-dist = [
     { name = "smolagents", specifier = ">=1.24.0" },
     { name = "sqlalchemy", specifier = ">=2.0.49" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.46.0" },
+    { name = "webauthn", specifier = ">=3.0.0" },
 ]
 
 [[package]]
@@ -310,6 +312,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
     { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "6.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/14/b02446bacfe44351b1689c04937ade007588f44570431880a6937e525e6c/cbor2-6.1.4.tar.gz", hash = "sha256:01ecc79a28f33d17331943ce508fc1e21f4b06553c73f874f4c77120d72b2ef9", size = 90840, upload-time = "2026-08-01T20:41:39.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/5d/c5374c76471ab41dff4420a276569a56352e83166374fba6f40fd0bde7ad/cbor2-6.1.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24da0a481294ac416e1e369e2d204b2b1d993cbd082d0d99fa3d6f5f27ae5e69", size = 407497, upload-time = "2026-08-01T20:41:15.189Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f9/b9f12a5e24d5ae355e4c0f6d37330a2bbedad3331247a223a51c4cd39d5e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0859a0837e6e2d4fe5f5b849f6475797e4db545da98c19db4b1d3487bd47aa22", size = 452191, upload-time = "2026-08-01T20:41:16.705Z" },
+    { url = "https://files.pythonhosted.org/packages/67/22/8224b01f95a6fe07b1a64082aea34d9f49068392b3de93f5f3a10c73c62e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c0f5f2d6d3b58e44146860c049f3c082207a4005588b8926d51bf937ab66773c", size = 462383, upload-time = "2026-08-01T20:41:18.17Z" },
+    { url = "https://files.pythonhosted.org/packages/92/52/437e4aa4f5df1fb41020d64b3d99a8239f0f99a3a75eb6ffa5cb66004b7f/cbor2-6.1.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:239db0f92d537fd29eaec4e40195fc3b2b48bc34a5887059658162489a9eb6ae", size = 518700, upload-time = "2026-08-01T20:41:19.592Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/2f5ea5bfe0fd800b3739c7df8679bdffa9f7def6b2f2fee064ada1c63e85/cbor2-6.1.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3f4a434c36bb0d33aeb48ddae8e8b673ca7e1f14545ee7cf4a4c7c39380ea9a2", size = 531243, upload-time = "2026-08-01T20:41:21.21Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c6/0beac64cb74cd3217f295f9bb0d64675e1809c683a31ea2a49ac9d4d1504/cbor2-6.1.4-cp314-cp314-win32.whl", hash = "sha256:6abcf072b8c0fdc8ad7902ee26a906cafbf3427d026b662ff21166a253f85e18", size = 285248, upload-time = "2026-08-01T20:41:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7d/4afa096ddc94049f5a514690891b02a18319e146ceb14465ce30c8340a8b/cbor2-6.1.4-cp314-cp314-win_amd64.whl", hash = "sha256:855764e02dc60ab9413acd044e997c3170000fdea6155d6c43a923a1d966dbe6", size = 313044, upload-time = "2026-08-01T20:41:24.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b5/e614cee861772f6b5c4d926b066d2e7dbc11e220b50ba716ba91e430fb0f/cbor2-6.1.4-cp314-cp314-win_arm64.whl", hash = "sha256:c6b28b928c5f2dbf47dffa12dce9c8e36fe6ac1c1358bc326499c0736263b66f", size = 304088, upload-time = "2026-08-01T20:41:25.431Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/41/3b28184154f6cbf7e47c1b7fb4a7a291c54f27a6f3a0a2f64b078c6a13e1/cbor2-6.1.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7336ff4cb7d161ec43b65eef43bf3e9bcab44bd152efb54dd637b7afe711254f", size = 401042, upload-time = "2026-08-01T20:41:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/a8624023b84b41c43a150a89517c104aed0e467bd258866f13be4c3ac0c6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8f1019494b0ec81a3df3ebb01b6acb446d5b946fe35845b1726379abd66a71da", size = 445301, upload-time = "2026-08-01T20:41:28.35Z" },
+    { url = "https://files.pythonhosted.org/packages/60/39/07dd0ea957c1f48673d3947f97ee36826efd4a824053dd0ec4df2f0c89d6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:179a794bf4be1d46ff190695929f65f0b42019c156919846ae539d2a7ec42e54", size = 459816, upload-time = "2026-08-01T20:41:29.839Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8e/2015175132a27c1daed434f671ac6d9c1311461995df47f201307700e0da/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9b904b8d0f4ddac9259197d21d121fae4cb8b555700d65bc12c5d46a2e6c2025", size = 511565, upload-time = "2026-08-01T20:41:31.939Z" },
+    { url = "https://files.pythonhosted.org/packages/82/66/420991095d9473614b205d4c4e40b5d3b9f1ee4410eb3c48c1e902947837/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:71fcf4f237d68bf4445bf45070f36f82b333f2e6a62612aa2c256683b51378a9", size = 527709, upload-time = "2026-08-01T20:41:33.413Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/7c/73057e7a38488a816a0d40ff9e7cd9f418800894582e2e48fb2f47ce66a2/cbor2-6.1.4-cp314-cp314t-win32.whl", hash = "sha256:7deccc50fd0b55c4c7dd265b144c5358a645121e457c0ae3722b5ad59832b257", size = 281462, upload-time = "2026-08-01T20:41:35.127Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/d5db22837cb566de733b9d1c418cdf1912ccb1efc7b179e295430b1d81a2/cbor2-6.1.4-cp314-cp314t-win_amd64.whl", hash = "sha256:f3fc7d15cba4174373df2496070faa4a927fe3ed772130d281808120aec7b61c", size = 309165, upload-time = "2026-08-01T20:41:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5f/ff2c6da83553a692219a0a62a21b57a27ded4405200e50db758a17fbaf15/cbor2-6.1.4-cp314-cp314t-win_arm64.whl", hash = "sha256:164ca22b509408435b2d8236c80c964e4fc77c085ab034569cd04c40d5cc8883", size = 298386, upload-time = "2026-08-01T20:41:38.392Z" },
 ]
 
 [[package]]
@@ -451,55 +477,52 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
-    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
-    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
-    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
-    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
-    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
-    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
-    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
 ]
 
 [[package]]
@@ -1873,6 +1896,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ad/2cf6d3fa2fae5c79e1ed9960c0d42badd0f94d81dd12b50604cdc839e648/pyopenssl-26.4.0-py3-none-any.whl", hash = "sha256:f0eb0cb2d581d3ad2b9c489468485e7f2ab6727d08401bcf9d824c3caddf3c1c", size = 56026, upload-time = "2026-08-01T19:50:48.94Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2444,6 +2479,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "webauthn"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cbor2" },
+    { name = "cryptography" },
+    { name = "pyasn1" },
+    { name = "pyasn1-modules" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/22/b19c91e850c4578b7d6cdb53453c5fe2f2e99d0c56e322c65c3caf1b3051/webauthn-3.0.0.tar.gz", hash = "sha256:324e54e1f6eeef486623b5d90df6fcd74ae04ff0c137d2b818a8f709b6ca3ab8", size = 160472, upload-time = "2026-06-29T22:40:33.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/d3/38d4efaedba74d854f88b60fd7b80ab37869032f9a9ad54d1892dab20241/webauthn-3.0.0-py3-none-any.whl", hash = "sha256:b5d0c02b6efa16be683f8a75abd2073f5e59a15f42623cc22c31f27600259e64", size = 73887, upload-time = "2026-06-29T22:40:32.171Z" },
 ]
 
 [[package]]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "paperagent",
       "version": "0.0.0",
       "dependencies": {
+        "@simplewebauthn/browser": "^13.3.0",
         "@tdesign-vue-next/chat": "^0.5.2",
         "docx-preview": "^0.3.7",
         "embla-carousel-vue": "^8.6.0",
@@ -1652,6 +1653,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
     },
     "node_modules/@tdesign-vue-next/chat": {
       "version": "0.5.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^13.3.0",
     "@tdesign-vue-next/chat": "^0.5.2",
     "docx-preview": "^0.3.7",
     "embla-carousel-vue": "^8.6.0",

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -25,6 +25,21 @@ export interface TokenResponse {
   token_type: string
 }
 
+export interface PasskeyOptionsResponse {
+  challenge_id: string
+  options: Record<string, any>
+}
+
+export interface PasskeyCredential {
+  id: number
+  name: string
+  device_type?: string | null
+  backed_up: boolean
+  transports?: string[] | null
+  created_at: string
+  last_used_at?: string | null
+}
+
 class AuthAPI {
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     return apiClient.request<T>(`/auth${endpoint}`, options)
@@ -52,6 +67,64 @@ class AuthAPI {
       headers: {
         Authorization: `Bearer ${token}`,
       },
+    })
+  }
+
+  async getPasskeyRegisterOptions(): Promise<PasskeyOptionsResponse> {
+    return this.request<PasskeyOptionsResponse>('/passkey/register/options', {
+      method: 'POST',
+    })
+  }
+
+  async verifyPasskeyRegister(
+    challengeId: string,
+    credential: object,
+    name?: string,
+  ): Promise<PasskeyCredential> {
+    return this.request<PasskeyCredential>('/passkey/register/verify', {
+      method: 'POST',
+      body: JSON.stringify({
+        challenge_id: challengeId,
+        credential,
+        name,
+      }),
+    })
+  }
+
+  async getPasskeyLoginOptions(email?: string): Promise<PasskeyOptionsResponse> {
+    return this.request<PasskeyOptionsResponse>('/passkey/login/options', {
+      method: 'POST',
+      body: JSON.stringify(email ? { email } : {}),
+    })
+  }
+
+  async verifyPasskeyLogin(
+    challengeId: string,
+    credential: object,
+  ): Promise<TokenResponse> {
+    return this.request<TokenResponse>('/passkey/login/verify', {
+      method: 'POST',
+      body: JSON.stringify({
+        challenge_id: challengeId,
+        credential,
+      }),
+    })
+  }
+
+  async listPasskeys(): Promise<PasskeyCredential[]> {
+    return this.request<PasskeyCredential[]>('/passkey/credentials')
+  }
+
+  async renamePasskey(id: number, name: string): Promise<PasskeyCredential> {
+    return this.request<PasskeyCredential>(`/passkey/credentials/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    })
+  }
+
+  async deletePasskey(id: number): Promise<void> {
+    await this.request(`/passkey/credentials/${id}`, {
+      method: 'DELETE',
     })
   }
 }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -324,6 +324,13 @@ const userOptions = [
     },
   },
   {
+    content: 'Passkey 管理',
+    value: 'passkey',
+    onClick: () => {
+      router.push('/passkey')
+    },
+  },
+  {
     content: '退出登录',
     value: 'logout',
     onClick: () => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,6 +5,7 @@ import Home from '@/views/Home.vue'
 import Work from '@/views/Work.vue'
 import Template from '@/views/Template.vue'
 import ApiKeyConfig from '@/views/ApiKeyConfig.vue'
+import PasskeySettings from '@/views/PasskeySettings.vue'
 import { useAuthStore } from '@/stores/auth'
 
 const router = createRouter({
@@ -44,6 +45,12 @@ const router = createRouter({
       name: 'ApiKeyConfig',
       component: ApiKeyConfig,
       meta: { requiresAuth: true }, // 需要登录才能访问
+    },
+    {
+      path: '/passkey',
+      name: 'PasskeySettings',
+      component: PasskeySettings,
+      meta: { requiresAuth: true },
     },
   ],
 })

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -101,6 +101,27 @@ export const useAuthStore = defineStore(
       initialized.value = false
     }
 
+    async function loginWithToken(accessToken: string) {
+      try {
+        loading.value = true
+        token.value = accessToken
+        localStorage.setItem('auth_token', accessToken)
+        await loadCurrentUser()
+        if (!user.value) {
+          return { success: false, error: '登录失败' }
+        }
+        return { success: true }
+      } catch (error) {
+        logout()
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : '登录失败',
+        }
+      } finally {
+        loading.value = false
+      }
+    }
+
     return {
       // 状态
       user,
@@ -115,6 +136,7 @@ export const useAuthStore = defineStore(
       // 方法
       register,
       login,
+      loginWithToken,
       logout,
       loadCurrentUser,
       initializeAuth, // 新增：导出初始化方法

--- a/frontend/src/utils/passkey.ts
+++ b/frontend/src/utils/passkey.ts
@@ -16,6 +16,23 @@ export function isPasskeySupported(): boolean {
   return browserSupportsWebAuthn()
 }
 
+export function isPasskeyOriginSupported(): boolean {
+  if (typeof window === 'undefined') return false
+  const host = window.location.hostname
+  if (host === 'localhost') return true
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)) return false
+  return window.isSecureContext
+}
+
+export function passkeyOriginHint(): string | null {
+  if (isPasskeyOriginSupported()) return null
+  const host = window.location.hostname
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)) {
+    return 'Passkey 不能使用 IP 访问，请改用 localhost 或 HTTPS 域名'
+  }
+  return 'Passkey 需要安全上下文（HTTPS 或 localhost）'
+}
+
 export function isPasskeyAutofillSupported(): Promise<boolean> {
   return browserSupportsWebAuthnAutofill()
 }

--- a/frontend/src/utils/passkey.ts
+++ b/frontend/src/utils/passkey.ts
@@ -1,0 +1,51 @@
+import {
+  browserSupportsWebAuthn,
+  browserSupportsWebAuthnAutofill,
+  startAuthentication,
+  startRegistration,
+  WebAuthnAbortService,
+} from '@simplewebauthn/browser'
+import type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+} from '@simplewebauthn/browser'
+
+export function isPasskeySupported(): boolean {
+  return browserSupportsWebAuthn()
+}
+
+export function isPasskeyAutofillSupported(): Promise<boolean> {
+  return browserSupportsWebAuthnAutofill()
+}
+
+export function cancelPasskeyCeremony(): void {
+  WebAuthnAbortService.cancelCeremony()
+}
+
+export async function createPasskey(
+  options: PublicKeyCredentialCreationOptionsJSON,
+): Promise<RegistrationResponseJSON> {
+  return startRegistration({ optionsJSON: options })
+}
+
+export async function assertPasskey(
+  options: PublicKeyCredentialRequestOptionsJSON,
+  useBrowserAutofill = false,
+): Promise<AuthenticationResponseJSON> {
+  return startAuthentication({
+    optionsJSON: options,
+    useBrowserAutofill,
+  })
+}
+
+export function isPasskeyCanceled(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const err = error as { name?: string; code?: string }
+  return (
+    err.name === 'NotAllowedError' ||
+    err.name === 'AbortError' ||
+    err.code === 'ERROR_CEREMONY_ABORTED'
+  )
+}

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -55,7 +55,7 @@
         </t-form-item>
 
         <t-form-item>
-          <t-button type="submit" theme="primary" size="large" block :loading="authStore.loading">
+          <t-button type="submit" theme="primary" size="large" block :loading="passwordLoading">
             {{ isLogin ? '登录' : '注册' }}
           </t-button>
         </t-form-item>
@@ -120,6 +120,7 @@ const passkeySupported = ref(false)
 const passkeyOriginOk = ref(true)
 const originHint = ref<string | null>(null)
 const passkeyLoading = ref(false)
+const passwordLoading = ref(false)
 let conditionalLoginActive = false
 
 // 检查URL参数，如果是注册模式则自动切换
@@ -243,6 +244,8 @@ onUnmounted(() => {
 
 const onSubmit = async ({ validateResult }: { validateResult: any }) => {
   if (validateResult === true) {
+    cancelPasskeyCeremony()
+    passwordLoading.value = true
     try {
       if (isLogin.value) {
         // 登录逻辑
@@ -281,6 +284,8 @@ const onSubmit = async ({ validateResult }: { validateResult: any }) => {
     } catch (error) {
       console.error('操作失败:', error)
       MessagePlugin.error('操作失败，请重试')
+    } finally {
+      passwordLoading.value = false
     }
   }
 }

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -61,7 +61,7 @@
         </t-form-item>
       </t-form>
 
-      <div v-if="isLogin && passkeySupported" class="passkey-section">
+      <div v-if="isLogin && passkeySupported && passkeyOriginOk" class="passkey-section">
         <div class="divider"><span>或</span></div>
         <t-button
           theme="default"
@@ -88,6 +88,7 @@
           <t-link theme="primary" @click="switchMode">立即登录</t-link>
         </p>
         <p v-if="isLogin" class="passkey-hint">登录后可在账户设置中添加 Passkey</p>
+        <p v-if="isLogin && originHint" class="passkey-hint">{{ originHint }}</p>
       </div>
     </div>
   </div>
@@ -105,7 +106,9 @@ import {
   cancelPasskeyCeremony,
   isPasskeyAutofillSupported,
   isPasskeyCanceled,
+  isPasskeyOriginSupported,
   isPasskeySupported,
+  passkeyOriginHint,
 } from '@/utils/passkey'
 
 const router = useRouter()
@@ -114,6 +117,8 @@ const authStore = useAuthStore()
 
 const isLogin = ref(true)
 const passkeySupported = ref(false)
+const passkeyOriginOk = ref(true)
+const originHint = ref<string | null>(null)
 const passkeyLoading = ref(false)
 let conditionalLoginActive = false
 
@@ -178,7 +183,7 @@ const finishPasskeyLogin = async (challengeId: string, credential: object) => {
 }
 
 const startConditionalLogin = async () => {
-  if (!isLogin.value || !passkeySupported.value) {
+  if (!isLogin.value || !passkeySupported.value || !passkeyOriginOk.value) {
     return
   }
   if (!(await isPasskeyAutofillSupported())) {
@@ -225,6 +230,8 @@ const onPasskeyLogin = async () => {
 
 onMounted(() => {
   passkeySupported.value = isPasskeySupported()
+  passkeyOriginOk.value = isPasskeyOriginSupported()
+  originHint.value = passkeyOriginHint()
   if (isLogin.value) {
     startConditionalLogin()
   }

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -17,7 +17,13 @@
         class="login-form"
       >
         <t-form-item name="email">
-          <t-input v-model="formData.email" placeholder="邮箱地址" type="email" clearable>
+          <t-input
+            v-model="formData.email"
+            placeholder="邮箱地址"
+            type="email"
+            autocomplete="username webauthn"
+            clearable
+          >
             <template #prefix-icon>
               <MailIcon />
             </template>
@@ -55,6 +61,23 @@
         </t-form-item>
       </t-form>
 
+      <div v-if="isLogin && passkeySupported" class="passkey-section">
+        <div class="divider"><span>或</span></div>
+        <t-button
+          theme="default"
+          variant="outline"
+          size="large"
+          block
+          :loading="passkeyLoading"
+          @click="onPasskeyLogin"
+        >
+          <template #icon>
+            <SecuredIcon />
+          </template>
+          使用 Passkey 登录
+        </t-button>
+      </div>
+
       <div class="form-footer">
         <p v-if="isLogin">
           还没有账户？
@@ -64,23 +87,35 @@
           已有账户？
           <t-link theme="primary" @click="switchMode">立即登录</t-link>
         </p>
+        <p v-if="isLogin" class="passkey-hint">登录后可在账户设置中添加 Passkey</p>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, reactive } from 'vue'
+import { ref, reactive, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { MessagePlugin } from 'tdesign-vue-next'
-import { MailIcon, LockOnIcon, UserIcon } from 'tdesign-icons-vue-next'
+import { MailIcon, LockOnIcon, UserIcon, SecuredIcon } from 'tdesign-icons-vue-next'
 import { useAuthStore } from '@/stores/auth'
+import { authAPI } from '@/api/auth'
+import {
+  assertPasskey,
+  cancelPasskeyCeremony,
+  isPasskeyAutofillSupported,
+  isPasskeyCanceled,
+  isPasskeySupported,
+} from '@/utils/passkey'
 
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
 
 const isLogin = ref(true)
+const passkeySupported = ref(false)
+const passkeyLoading = ref(false)
+let conditionalLoginActive = false
 
 // 检查URL参数，如果是注册模式则自动切换
 if (route.query.mode === 'register') {
@@ -120,12 +155,84 @@ const rules = {
 
 const switchMode = () => {
   isLogin.value = !isLogin.value
+  cancelPasskeyCeremony()
   // 清空表单数据
   formData.email = ''
   formData.username = ''
   formData.password = ''
   formData.confirmPassword = ''
+  if (isLogin.value) {
+    startConditionalLogin()
+  }
 }
+
+const finishPasskeyLogin = async (challengeId: string, credential: object) => {
+  const tokenResponse = await authAPI.verifyPasskeyLogin(challengeId, credential)
+  const result = await authStore.loginWithToken(tokenResponse.access_token)
+  if (result.success) {
+    MessagePlugin.success('登录成功')
+    router.push('/home')
+  } else {
+    MessagePlugin.error(result.error || '登录失败')
+  }
+}
+
+const startConditionalLogin = async () => {
+  if (!isLogin.value || !passkeySupported.value) {
+    return
+  }
+  if (!(await isPasskeyAutofillSupported())) {
+    return
+  }
+  if (conditionalLoginActive) return
+  conditionalLoginActive = true
+  try {
+    const { challenge_id, options } = await authAPI.getPasskeyLoginOptions()
+    const assertion = await assertPasskey(options as any, true)
+    await finishPasskeyLogin(challenge_id, assertion)
+  } catch (error) {
+    if (!isPasskeyCanceled(error)) {
+      console.warn('Passkey 自动填充登录未完成:', error)
+    }
+  } finally {
+    conditionalLoginActive = false
+  }
+}
+
+const onPasskeyLogin = async () => {
+  if (!passkeySupported.value) {
+    MessagePlugin.warning('当前浏览器不支持 Passkey')
+    return
+  }
+  passkeyLoading.value = true
+  try {
+    const email = formData.email.trim() || undefined
+    const { challenge_id, options } = await authAPI.getPasskeyLoginOptions(email)
+    const assertion = await assertPasskey(options as any)
+    await finishPasskeyLogin(challenge_id, assertion)
+  } catch (error) {
+    if (isPasskeyCanceled(error)) {
+      MessagePlugin.info('已取消 Passkey 登录')
+    } else {
+      console.error('Passkey 登录失败:', error)
+      MessagePlugin.error(error instanceof Error ? error.message : 'Passkey 登录失败')
+    }
+  } finally {
+    passkeyLoading.value = false
+    startConditionalLogin()
+  }
+}
+
+onMounted(() => {
+  passkeySupported.value = isPasskeySupported()
+  if (isLogin.value) {
+    startConditionalLogin()
+  }
+})
+
+onUnmounted(() => {
+  cancelPasskeyCeremony()
+})
 
 const onSubmit = async ({ validateResult }: { validateResult: any }) => {
   if (validateResult === true) {
@@ -226,5 +333,35 @@ const onSubmit = async ({ validateResult }: { validateResult: any }) => {
 .form-footer p {
   margin: 0;
   color: #7f8c8d;
+}
+
+.passkey-section {
+  margin: -10px 0 24px;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  color: #b0b8bf;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #e8edf2;
+}
+
+.divider span {
+  padding: 0 12px;
+}
+
+.passkey-hint {
+  margin-top: 12px !important;
+  font-size: 12px;
+  color: #95a5a6;
 }
 </style>

--- a/frontend/src/views/PasskeySettings.vue
+++ b/frontend/src/views/PasskeySettings.vue
@@ -1,0 +1,275 @@
+<template>
+  <div class="passkey-page">
+    <Sidebar
+      :is-sidebar-collapsed="isSidebarCollapsed"
+      :active-history-id="activeHistoryId"
+      @toggle-sidebar="toggleSidebar"
+      @create-new-task="createNewTask"
+      @select-history="selectHistory"
+    />
+
+    <div class="main-content">
+      <div class="workspace-header">
+        <h1>Passkey 管理</h1>
+        <p>使用指纹、面容或安全密钥登录，无需每次输入密码</p>
+      </div>
+
+      <div class="passkey-content">
+        <t-card title="我的 Passkey">
+          <template #actions>
+            <t-button
+              theme="primary"
+              :disabled="!passkeySupported"
+              :loading="registering"
+              @click="showAddDialog = true"
+            >
+              添加 Passkey
+            </t-button>
+          </template>
+
+          <t-alert v-if="!passkeySupported" theme="warning" message="当前浏览器不支持 Passkey，请使用最新版 Chrome、Edge、Safari 或 Firefox。" />
+
+          <t-table
+            :data="passkeys"
+            :columns="columns"
+            row-key="id"
+            :loading="loading"
+            empty="还没有 Passkey。添加后即可在登录页使用指纹、面容或安全密钥登录。"
+          >
+            <template #backed_up="{ row }">
+              <t-tag :theme="row.backed_up ? 'success' : 'default'" variant="light">
+                {{ row.backed_up ? '已同步' : '仅本机' }}
+              </t-tag>
+            </template>
+            <template #created_at="{ row }">
+              {{ formatDate(row.created_at) }}
+            </template>
+            <template #last_used_at="{ row }">
+              {{ row.last_used_at ? formatDate(row.last_used_at) : '尚未使用' }}
+            </template>
+            <template #operation="{ row }">
+              <t-space>
+                <t-link theme="primary" @click="openRename(row)">重命名</t-link>
+                <t-link theme="danger" @click="confirmDelete(row)">删除</t-link>
+              </t-space>
+            </template>
+          </t-table>
+        </t-card>
+      </div>
+    </div>
+
+    <t-dialog
+      v-model:visible="showAddDialog"
+      header="添加 Passkey"
+      :confirm-btn="{ content: '开始绑定', loading: registering }"
+      @confirm="registerPasskey"
+    >
+      <t-form>
+        <t-form-item label="名称">
+          <t-input v-model="newPasskeyName" placeholder="例如：我的笔记本、iPhone" maxlength="100" />
+        </t-form-item>
+      </t-form>
+      <p class="dialog-hint">浏览器将弹出系统提示，请使用指纹、面容、PIN 或安全密钥完成绑定。</p>
+    </t-dialog>
+
+    <t-dialog
+      v-model:visible="showRenameDialog"
+      header="重命名 Passkey"
+      :confirm-btn="{ content: '保存', loading: renaming }"
+      @confirm="saveRename"
+    >
+      <t-input v-model="renameValue" placeholder="Passkey 名称" maxlength="100" />
+    </t-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next'
+import Sidebar from '@/components/Sidebar.vue'
+import { authAPI, type PasskeyCredential } from '@/api/auth'
+import { createPasskey, isPasskeyCanceled, isPasskeySupported } from '@/utils/passkey'
+
+const router = useRouter()
+const isSidebarCollapsed = ref(window.innerWidth <= 768)
+const activeHistoryId = ref<number | null>(null)
+const passkeySupported = ref(false)
+const loading = ref(false)
+const registering = ref(false)
+const renaming = ref(false)
+const passkeys = ref<PasskeyCredential[]>([])
+const showAddDialog = ref(false)
+const showRenameDialog = ref(false)
+const newPasskeyName = ref('我的设备')
+const renameValue = ref('')
+const renamingId = ref<number | null>(null)
+
+const columns = [
+  { colKey: 'name', title: '名称', minWidth: 140 },
+  { colKey: 'backed_up', title: '同步', width: 100 },
+  { colKey: 'created_at', title: '添加时间', width: 180 },
+  { colKey: 'last_used_at', title: '最近使用', width: 180 },
+  { colKey: 'operation', title: '操作', width: 140, fixed: 'right' },
+]
+
+const toggleSidebar = () => {
+  isSidebarCollapsed.value = !isSidebarCollapsed.value
+}
+
+const createNewTask = () => {
+  router.push('/home')
+}
+
+const selectHistory = (id: number) => {
+  router.push(`/work/${id}`)
+}
+
+const formatDate = (dateString: string) => {
+  if (!dateString) return ''
+  return new Date(dateString).toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const loadPasskeys = async () => {
+  loading.value = true
+  try {
+    passkeys.value = await authAPI.listPasskeys()
+  } catch (error) {
+    MessagePlugin.error(error instanceof Error ? error.message : '加载 Passkey 失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const registerPasskey = async () => {
+  if (!passkeySupported.value) {
+    MessagePlugin.warning('当前浏览器不支持 Passkey')
+    return
+  }
+  registering.value = true
+  try {
+    const { challenge_id, options } = await authAPI.getPasskeyRegisterOptions()
+    const credential = await createPasskey(options as any)
+    await authAPI.verifyPasskeyRegister(
+      challenge_id,
+      credential,
+      newPasskeyName.value.trim() || undefined,
+    )
+    MessagePlugin.success('Passkey 添加成功')
+    showAddDialog.value = false
+    newPasskeyName.value = '我的设备'
+    await loadPasskeys()
+  } catch (error) {
+    if (isPasskeyCanceled(error)) {
+      MessagePlugin.info('已取消添加 Passkey')
+    } else {
+      console.error('添加 Passkey 失败:', error)
+      MessagePlugin.error(error instanceof Error ? error.message : '添加 Passkey 失败')
+    }
+  } finally {
+    registering.value = false
+  }
+}
+
+const openRename = (row: PasskeyCredential) => {
+  renamingId.value = row.id
+  renameValue.value = row.name
+  showRenameDialog.value = true
+}
+
+const saveRename = async () => {
+  if (!renamingId.value) return
+  const name = renameValue.value.trim()
+  if (!name) {
+    MessagePlugin.warning('请输入名称')
+    return
+  }
+  renaming.value = true
+  try {
+    await authAPI.renamePasskey(renamingId.value, name)
+    MessagePlugin.success('已更新名称')
+    showRenameDialog.value = false
+    await loadPasskeys()
+  } catch (error) {
+    MessagePlugin.error(error instanceof Error ? error.message : '重命名失败')
+  } finally {
+    renaming.value = false
+  }
+}
+
+const confirmDelete = (row: PasskeyCredential) => {
+  const dialog = DialogPlugin.confirm({
+    header: '删除 Passkey',
+    body: `确定删除「${row.name}」吗？删除后将无法再用它登录。`,
+    confirmBtn: { content: '删除', theme: 'danger' },
+    onConfirm: async () => {
+      try {
+        await authAPI.deletePasskey(row.id)
+        MessagePlugin.success('已删除')
+        dialog.destroy()
+        await loadPasskeys()
+      } catch (error) {
+        MessagePlugin.error(error instanceof Error ? error.message : '删除失败')
+      }
+    },
+  })
+}
+
+onMounted(async () => {
+  passkeySupported.value = isPasskeySupported()
+  await loadPasskeys()
+})
+</script>
+
+<style scoped>
+.passkey-page {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+  background: #f5f7fa;
+  overflow: hidden;
+}
+
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.workspace-header {
+  padding: 15px 30px;
+  background: white;
+  border-bottom: 1px solid #eee;
+}
+
+.workspace-header h1 {
+  margin: 0 0 8px 0;
+  color: #2c3e50;
+  font-size: 1.5em;
+}
+
+.workspace-header p {
+  margin: 0;
+  color: #7f8c8d;
+  font-size: 0.9em;
+}
+
+.passkey-content {
+  flex: 1;
+  padding: 20px 30px;
+  overflow-y: auto;
+}
+
+.dialog-hint {
+  margin: 8px 0 0;
+  color: #7f8c8d;
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/views/PasskeySettings.vue
+++ b/frontend/src/views/PasskeySettings.vue
@@ -19,7 +19,7 @@
           <template #actions>
             <t-button
               theme="primary"
-              :disabled="!passkeySupported"
+              :disabled="!passkeySupported || !!originHint"
               :loading="registering"
               @click="showAddDialog = true"
             >
@@ -28,6 +28,7 @@
           </template>
 
           <t-alert v-if="!passkeySupported" theme="warning" message="当前浏览器不支持 Passkey，请使用最新版 Chrome、Edge、Safari 或 Firefox。" />
+          <t-alert v-else-if="originHint" theme="warning" :message="originHint" />
 
           <t-table
             :data="passkeys"
@@ -89,12 +90,13 @@ import { useRouter } from 'vue-router'
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next'
 import Sidebar from '@/components/Sidebar.vue'
 import { authAPI, type PasskeyCredential } from '@/api/auth'
-import { createPasskey, isPasskeyCanceled, isPasskeySupported } from '@/utils/passkey'
+import { createPasskey, isPasskeyCanceled, isPasskeySupported, passkeyOriginHint } from '@/utils/passkey'
 
 const router = useRouter()
 const isSidebarCollapsed = ref(window.innerWidth <= 768)
 const activeHistoryId = ref<number | null>(null)
 const passkeySupported = ref(false)
+const originHint = ref<string | null>(null)
 const loading = ref(false)
 const registering = ref(false)
 const renaming = ref(false)
@@ -152,17 +154,18 @@ const registerPasskey = async () => {
     MessagePlugin.warning('当前浏览器不支持 Passkey')
     return
   }
+  if (originHint.value) {
+    MessagePlugin.warning(originHint.value)
+    return
+  }
+  const name = newPasskeyName.value.trim()
+  showAddDialog.value = false
   registering.value = true
   try {
     const { challenge_id, options } = await authAPI.getPasskeyRegisterOptions()
     const credential = await createPasskey(options as any)
-    await authAPI.verifyPasskeyRegister(
-      challenge_id,
-      credential,
-      newPasskeyName.value.trim() || undefined,
-    )
+    await authAPI.verifyPasskeyRegister(challenge_id, credential, name || undefined)
     MessagePlugin.success('Passkey 添加成功')
-    showAddDialog.value = false
     newPasskeyName.value = '我的设备'
     await loadPasskeys()
   } catch (error) {
@@ -223,6 +226,7 @@ const confirmDelete = (row: PasskeyCredential) => {
 
 onMounted(async () => {
   passkeySupported.value = isPasskeySupported()
+  originHint.value = passkeyOriginHint()
   await loadPasskeys()
 })
 </script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动说明

为 PaperAgent 增加 **Passkey（WebAuthn）** 登录，密码登录保持不变。

### 使用方式
1. 使用邮箱密码登录后，打开侧边栏用户菜单中的 **Passkey 管理**
2. 绑定指纹 / 面容 / PIN / 安全密钥
3. 下次在登录页点击 **使用 Passkey 登录**（支持可发现凭证，可不填邮箱；若已填邮箱则只允许该账号的 Passkey）
4. 支持浏览器 Passkey 自动填充（邮箱框 `autocomplete="username webauthn"`）

### 后端
- 新增 `webauthn_credentials`、`webauthn_challenges` 表（Alembic 迁移 + `create_all` 兼容开发库）
- 接口前缀：`/auth/passkey/*`（注册选项/校验、登录选项/校验、列表、重命名、删除）
- RP ID / Origin 默认从请求 `Origin` 推导，可用 `WEBAUTHN_RP_ID`、`WEBAUTHN_ORIGIN`、`WEBAUTHN_ORIGINS` 覆盖
- Passkey 需要 **HTTPS 或 localhost**（IP 如 `127.0.0.1` 不能作为 RP ID）

### 前端
- 登录页增加 Passkey 按钮
- 新增 `/passkey` 管理页
- 通过 IP 访问时提示改用 localhost / HTTPS 域名

### 测试
- `backend/tests/test_passkey.py`：选项生成、绑定、登录签发 JWT、挑战一次性、过期拒绝、跨用户删除拒绝
- Chrome 虚拟 authenticator 端到端：绑定 Passkey 后可无密码登录

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db91edf3-1105-445a-8ba6-4484da31ecf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db91edf3-1105-445a-8ba6-4484da31ecf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

