### PR TITLE
fix: 修复 Alembic 双 head 导致 upgrade head 失败

### DIFF
--- a/backend/alembic/versions/c4e8a1b2d9f0_add_webauthn_passkey_tables.py
+++ b/backend/alembic/versions/c4e8a1b2d9f0_add_webauthn_passkey_tables.py
@@ -1,7 +1,7 @@
 """add webauthn passkey tables
 
 Revision ID: c4e8a1b2d9f0
-Revises: 906ca23fbfe1
+Revises: 736361c89d6a
 Create Date: 2026-08-24 07:10:00.000000
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 revision: str = "c4e8a1b2d9f0"
-down_revision: Union[str, Sequence[str], None] = "906ca23fbfe1"
+down_revision: Union[str, Sequence[str], None] = "736361c89d6a"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

容器启动执行 `alembic upgrade head` 失败：

```
Multiple head revisions are present for given argument 'head'
```

Passkey 表迁移 `c4e8a1b2d9f0` 的父版本写成了 `906ca23fbfe1`，而 `736361c89d6a`（output_format）已经从同一个父版本长出来，形成两个 head。

## 修复

把 `c4e8a1b2d9f0` 的 `down_revision` 改为 `736361c89d6a`，迁移链恢复为单线：

`2952aa9a98f3 → 1db1ebc908e4 → 906ca23fbfe1 → 736361c89d6a → c4e8a1b2d9f0`

本地已确认 `alembic heads` 只剩 `c4e8a1b2d9f0`。

已部署环境若停在 `736361c89d6a`，这次升级会正常补上 Passkey 表。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db91edf3-1105-445a-8ba6-4484da31ecf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db91edf3-1105-445a-8ba6-4484da31ecf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

